### PR TITLE
fix non-working WebService::Simple::AWS

### DIFF
--- a/lib/WebService/Simple.pm
+++ b/lib/WebService/Simple.pm
@@ -76,6 +76,8 @@ sub new {
     return $self;
 }
 
+sub _agent       { "libwww-perl/$LWP::VERSION+". __PACKAGE__ .'/'.$VERSION }
+
 sub base_url        { $_[0]->{base_url} }
 sub basic_params    { $_[0]->{basic_params} }
 sub response_parser { $_[0]->{response_parser} }

--- a/lib/WebService/Simple.pm
+++ b/lib/WebService/Simple.pm
@@ -299,6 +299,9 @@ Return reequest URL.
 
 =item cache
 
+Each request is prepended by an optional cache look-up. If you suppliy a cache
+object upon new(), the module will look into the cache first.
+
 =item response_parser
 
 =back

--- a/lib/WebService/Simple.pm
+++ b/lib/WebService/Simple.pm
@@ -149,7 +149,10 @@ sub get {
     my $uri = $self->request_url(
         url        => $self->base_url,
         extra_path => $url,
-        params     => $extra
+        params     => {
+                %{ $extra },
+                %{ $self->{basic_params} },
+        }
     );
 
     warn "Request URL is $uri\n" if $self->{debug};


### PR DESCRIPTION
This patch to the base class is actually meant to fix the Amazon wrapper class:

The sub _request_url_ in WebService::Simple and the overloaded one in package _WebService::Simple::AWS_ are handling _params_ in a different way. My fix reunifies these two styles again in _get()_ - but it's probably better that you decide how parameters should be handled, and where. Also, my fix does not remedy post() etc.

So please regard my patch only as a quick fix to illustrate the problem - and then patch _WebService::Simple::AWS_ or _WebService::Simple_ according to your coding style.

:+1: for a nice and light library
