### PR TITLE
Optional no compression, or no croak() on HTTP is_error

### DIFF
--- a/lib/WebService/Simple.pm
+++ b/lib/WebService/Simple.pm
@@ -330,10 +330,23 @@ Return request URL.
 
 =item cache
 
-Each request is prepended by an optional cache look-up. If you supply a cache
-object upon new(), the module will look into the cache first.
+Each request is prepended by an optional cache look-up. If you supply a Cache
+object to new(), the module will look into the cache first.
+
+  my $cache   = Cache::File->new(
+      cache_root      => '/tmp/mycache',
+      default_expires => '30 min',
+  );
+  
+  my $flickr = WebService::Simple->new(
+      base_url => "http://api.flickr.com/services/rest/",
+      cache    => $cache,
+      param    => { api_key => "your_api_key, }
+  );
 
 =item response_parser
+
+See PARSERS below.
 
 =back
 
@@ -399,20 +412,6 @@ including this module:
 
 This allows great flexibility in handling different Web Services
 
-=head1 CACHING
-
-You can cache the response of Web Service by using Cache object.
-
-  my $cache   = Cache::File->new(
-      cache_root      => '/tmp/mycache',
-      default_expires => '30 min',
-  );
-  
-  my $flickr = WebService::Simple->new(
-      base_url => "http://api.flickr.com/services/rest/",
-      cache    => $cache,
-      param    => { api_key => "your_api_key, }
-  );
 
 =head1 REPOSITORY
 


### PR DESCRIPTION
Two last things (hopefully not annoying you yet):

Major:
By default, the module croaks upon is_error. My understanding of a module die()ing or croak()ing is that the _module user_ is doing something wrong - for example, here, not providing a base_url on new(). But when the remote API server might go away or return some error, I think the module shouldn't die. (Which would exit/interrupt a CGI - unless you eval {} or try {} catch ..both leading to unreadable code IMHO).
Thus, I've proposed a new module switch which allows a user disable these croak()s, without changing the module's API, on which some users may already rely. ...Although I think it should be the default.

Minor:
Allow a user to disable HTTP compression. This is useful during debugging, when you receive error responses and Dumper() the response for inspection, for example. Net::Amazon has it as well.
