### PR TITLE
Add HTTP::Message to prereqs

### DIFF
--- a/META.json
+++ b/META.json
@@ -60,6 +60,7 @@
             "Data::Dumper" : "0",
             "Digest::MD5" : "0",
             "Hash::MultiValue" : "0",
+            "HTTP::Message" : "0",
             "JSON" : "2.0",
             "LWP::Protocol::https" : "0",
             "LWP::UserAgent" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'Class::Data::ConfigHash';
 requires 'Class::Inspector';
 requires 'Data::Dumper';
 requires 'Digest::MD5';
+requires 'HTTP::Message';
 requires 'JSON', '2.0';
 requires 'LWP::UserAgent';
 requires 'LWP::Protocol::https';


### PR DESCRIPTION
Noticed recently added HTTP::Message was not part of pre-requisite modules in META.json
