### PR TITLE
add support for application/json POST requests

### DIFF
--- a/lib/WebService/Simple.pm
+++ b/lib/WebService/Simple.pm
@@ -66,18 +66,15 @@ sub new {
                 : %{ $config->{args} } );
         }
     }
-    my $compression = delete $args{compression};
-    my $croak = delete $args{croak};
-    my $content_type = delete $args{content_type};
 
     my $self = $class->SUPER::new(%args);
     $self->{base_url}        = $base_url;
     $self->{basic_params}    = $basic_params;
     $self->{response_parser} = $response_parser;
     $self->{cache}           = $cache;
-    $self->{compression}     = $compression;
-    $self->{content_type}    = $content_type;
-    $self->{croak}           = $croak;
+    $self->{compression}     = delete $args{compression};
+    $self->{content_type}    = delete $args{content_type};
+    $self->{croak}           = delete $args{croak};
     $self->{debug}           = $debug;
 
     if($self->{content_type} && $self->{content_type} eq 'application/json'){

--- a/lib/WebService/Simple/Parser/JSON.pm
+++ b/lib/WebService/Simple/Parser/JSON.pm
@@ -17,6 +17,15 @@ sub new
     return $self;
 }
 
+sub parse_request
+{
+    my $self = shift;
+#   my $content = $_[0]->decoded_content;
+#   # JSONP to pure JSON
+#   $content =~ s/[a-zA-Z_\$][a-zA-Z0-9_\$]*\s*\((.+)\)\s*;?\s*$/$1/;
+    $self->{json}->encode( $_[0] );
+}
+
 sub parse_response
 {
     my $self = shift;


### PR DESCRIPTION
Some APIs require the _post()_ body/message/content to be a JSON string. I've added this ability to the module, as it - so far - was always doing urlencoded/form post'ing.

Especially using the _$self->{request_parser_json}_ variable as flag and as code-ref is very hackish, and introduces two or three new internal ways of handling things, for example this __init_request_parser_json() method, ...so feel free to rewrite, change or decline the pull-request altogether. Ideally, the module should offer to encode a request as XML just as well, but I couldn't think of an elegant way of handling both cases, by properly re-using the parser modules, etc. Might need a bit of re-thinking on your part, of the Parser interfaces, to allow both directions: parse_response and _parse_request_ (or better _encode_request_). Well, at least this pull-request can give you a general idea of the new feature.
