### PR TITLE
Use parse_string instead of XMLin

### DIFF
--- a/lib/WebService/Simple/Parser/XML/Simple.pm
+++ b/lib/WebService/Simple/Parser/XML/Simple.pm
@@ -17,7 +17,7 @@ sub new {
 
 sub parse_response {
     my $self = shift;
-    $self->{xs}->XMLin( $_[0]->decoded_content );
+    $self->{xs}->parse_string( $_[0]->decoded_content );
 }
 
 1;

--- a/t/02_parser_xml_simple.t
+++ b/t/02_parser_xml_simple.t
@@ -1,10 +1,13 @@
 use strict;
-use Test::More ( tests => 4 );
+use Test::More ( tests => 6 );
+
+use HTTP::Response;
 
 my $flickr_api_key = $ENV{FLICKR_API_KEY};
 BEGIN
 {
     use_ok("WebService::Simple");
+    use_ok("WebService::Simple::Parser::XML::Simple");
 }
 
 {
@@ -36,4 +39,15 @@ BEGIN
             }
         );
     }
+}
+
+{
+    my $parser   = WebService::Simple::Parser::XML::Simple->new;
+    my $response = HTTP::Response->new(undef, undef, undef, 'like.filename');
+
+    eval {
+        $parser->parse_response($response);
+    };
+
+    like($@, qr{\bsyntax error\b}, 'parse as string');
 }


### PR DESCRIPTION
XMLin() handles some strings as filepath.
If response body is not XML, parse_response() raises incorrect error message.
Like `File does not exist: like.filename ...`